### PR TITLE
Add spotsAvailable calculation for Events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,21 @@ RUN rm -rf ${WORK_DIR}/service/test
 RUN rm -rf ${WORK_DIR}/service/src/test
 RUN rm -rf ${WORK_DIR}/common/src/test
 
+
+# The port that YOU should expose when you run this in a container
+# see https://docs.docker.com/engine/reference/builder/#expose
+
+EXPOSE 8081
+
+
+
+# Build the software
+
+RUN mvn -T 2C install
+
+RUN mvn -T 2C package
+
+
+
 # Set a default command to execute
 CMD /lucys-love-bus-backend/deploy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ FROM openjdk:8
 # Set the working dir env var
 ENV WORK_DIR /lucys-love-bus-backend
 
-# Expose the container ports to the host
+
+# The port that YOU should expose when you run this in a container
+# see https://docs.docker.com/engine/reference/builder/#expose
 EXPOSE 8081
+
 
 # Set default working directory
 WORKDIR ${WORK_DIR}
@@ -26,21 +29,6 @@ ADD scripts ${WORK_DIR}
 RUN rm -rf ${WORK_DIR}/service/test
 RUN rm -rf ${WORK_DIR}/service/src/test
 RUN rm -rf ${WORK_DIR}/common/src/test
-
-
-# The port that YOU should expose when you run this in a container
-# see https://docs.docker.com/engine/reference/builder/#expose
-
-EXPOSE 8081
-
-
-
-# Build the software
-
-RUN mvn -T 2C install
-
-RUN mvn -T 2C package
-
 
 
 # Set a default command to execute

--- a/api/src/main/java/com/codeforcommunity/dto/userEvents/responses/SingleEventResponse.java
+++ b/api/src/main/java/com/codeforcommunity/dto/userEvents/responses/SingleEventResponse.java
@@ -6,13 +6,15 @@ public class SingleEventResponse {
   private int id;
   private String title;
   private int spotsAvailable;
+  private int capacity;
   private String thumbnail;
   private EventDetails details;
 
-  public SingleEventResponse(int id, String title, int spotsAvailable, String thumbnail, EventDetails details) {
+  public SingleEventResponse(int id, String title, int spotsAvailable, int capacity, String thumbnail, EventDetails details) {
     this.id = id;
     this.title = title;
     this.spotsAvailable = spotsAvailable;
+    this.capacity = capacity;
     this.thumbnail = thumbnail;
     this.details = details;
   }
@@ -29,6 +31,10 @@ public class SingleEventResponse {
 
   public int getSpotsAvailable() {
     return spotsAvailable;
+  }
+
+  public int getCapacity() {
+    return capacity;
   }
 
   public String getThumbnail() {

--- a/service/src/main/java/com/codeforcommunity/processor/EventsProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/EventsProcessorImpl.java
@@ -11,8 +11,11 @@ import com.codeforcommunity.dto.userEvents.responses.GetEventsResponse;
 import com.codeforcommunity.enums.PrivilegeLevel;
 import com.codeforcommunity.exceptions.AdminOnlyRouteException;
 import org.jooq.*;
+import org.jooq.DSLContext;
+import org.jooq.Result;
 import org.jooq.generated.tables.pojos.Events;
 import org.jooq.generated.tables.records.EventsRecord;
+import org.jooq.generated.tables.records.UserEventsRecord;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -154,7 +157,7 @@ public class EventsProcessorImpl implements IEventsProcessor {
     EventDetails details = new EventDetails(event.getDescription(), event.getLocation(),
         event.getStartTime(), event.getEndTime());
     return new SingleEventResponse(event.getId(), event.getTitle(),
-        event.getCapacity(), event.getThumbnail(), details);
+        getSpotsAvailable(event), event.getCapacity(), event.getThumbnail(), details);
   }
 
   /**
@@ -172,4 +175,15 @@ public class EventsProcessorImpl implements IEventsProcessor {
     return newRecord;
   }
 
+  /**
+   * Returns the count of spaces available for the given event.
+   *
+   * @param event the Events object to find get the spaces available for.
+   * @return an int representing the number of available spaces.
+   */
+  private int getSpotsAvailable(Events event) {
+    Result<UserEventsRecord> userEventsRecord = db.selectFrom(USER_EVENTS)
+        .where(USER_EVENTS.EVENT_ID.eq(event.getId())).fetch();
+    return event.getCapacity() - userEventsRecord.size();
+  }
 }

--- a/service/src/main/java/com/codeforcommunity/processor/EventsProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/EventsProcessorImpl.java
@@ -182,8 +182,7 @@ public class EventsProcessorImpl implements IEventsProcessor {
    * @return an int representing the number of available spaces.
    */
   private int getSpotsAvailable(Events event) {
-    Result<UserEventsRecord> userEventsRecord = db.selectFrom(USER_EVENTS)
-        .where(USER_EVENTS.EVENT_ID.eq(event.getId())).fetch();
-    return event.getCapacity() - userEventsRecord.size();
+    int userEvents = db.fetchCount(USER_EVENTS.where(USER_EVENTS.EVENT_ID.eq(event.getId())));
+    return event.getCapacity() - userEvents;
   }
 }

--- a/service/src/main/java/com/codeforcommunity/processor/EventsProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/EventsProcessorImpl.java
@@ -157,7 +157,7 @@ public class EventsProcessorImpl implements IEventsProcessor {
     EventDetails details = new EventDetails(event.getDescription(), event.getLocation(),
         event.getStartTime(), event.getEndTime());
     return new SingleEventResponse(event.getId(), event.getTitle(),
-        getSpotsAvailable(event), event.getCapacity(), event.getThumbnail(), details);
+        getSpotsLeft(event.getId()), event.getCapacity(), event.getThumbnail(), details);
   }
 
   /**
@@ -173,16 +173,5 @@ public class EventsProcessorImpl implements IEventsProcessor {
     newRecord.setStartTime(request.getDetails().getStart());
     newRecord.setEndTime(request.getDetails().getEnd());
     return newRecord;
-  }
-
-  /**
-   * Returns the count of spaces available for the given event.
-   *
-   * @param event the Events object to find get the spaces available for.
-   * @return an int representing the number of available spaces.
-   */
-  private int getSpotsAvailable(Events event) {
-    int userEvents = db.fetchCount(USER_EVENTS.where(USER_EVENTS.EVENT_ID.eq(event.getId())));
-    return event.getCapacity() - userEvents;
   }
 }


### PR DESCRIPTION
This is the work for [this ticket](https://trello.com/c/RvTyNTGG/131-llb-add-capacity-field-to-event-apis). 

[Api docs](https://github.com/Code-4-Community/dev-spikes/blob/master/api-spec/llb/api-spec.md) mention a lot of other endpoints that may be relevant, but they're not available in master yet so I skipped them for now. All that's available in the `EventsProcessor` now are the routes to create an event and get a single event (unless I'm completely missing something).

Also, this has a minor update to one of the comments in the Dockerfile. It should be noted that the `EXPOSE` Dockerfile keyword is basically only used as documentation for the person running the container that the given port should be port-forwarded by the user. See the [docker documentation](https://docs.docker.com/engine/reference/builder/#expose).
>The `EXPOSE` instruction does not actually publish the port. It functions as a type of documentation between the person who builds the image and the person who runs the container, about which ports are intended to be published. To actually publish the port when running the container, use the `-p` flag on docker run to publish and map one or more ports, or the `-P` flag to publish all exposed ports and map them to high-order ports.