### PR TITLE
Update JooqMock

### DIFF
--- a/service/src/test/java/com.codeforcommunity/JooqMock.java
+++ b/service/src/test/java/com.codeforcommunity/JooqMock.java
@@ -49,10 +49,7 @@ public class JooqMock implements MockDataProvider {
      * Constructor for 'UNKNOWN' and 'DROP/CREATE' operations.
      */
     Operations() {
-      recordReturns = new ArrayList<>();
-      recordReturns.add(() -> null);
-      handlerSqlCalls = new ArrayList<>();
-      handlerSqlBindings = new ArrayList<>();
+      this(() -> null);
     }
 
     /**
@@ -62,10 +59,7 @@ public class JooqMock implements MockDataProvider {
      * @param record The record to be returned during the first call of this operation.
      */
     Operations(Record record) {
-      recordReturns = new ArrayList<>();
-      recordReturns.add(() -> createResult(record));
-      handlerSqlCalls = new ArrayList<>();
-      handlerSqlBindings = new ArrayList<>();
+      this(() -> createResult(record));
     }
 
     /**
@@ -75,10 +69,7 @@ public class JooqMock implements MockDataProvider {
      * @param records The record to be returned during the first call of this operation.
      */
     Operations(List<? extends Record> records) {
-      recordReturns = new ArrayList<>();
-      recordReturns.add(() -> createResult(records));
-      handlerSqlCalls = new ArrayList<>();
-      handlerSqlBindings = new ArrayList<>();
+      this(() -> createResult(records));
     }
 
     /**
@@ -92,28 +83,6 @@ public class JooqMock implements MockDataProvider {
       recordReturns.add(recordFunction);
       handlerSqlCalls = new ArrayList<>();
       handlerSqlBindings = new ArrayList<>();
-    }
-
-    private Result<? extends Record> createResult(Record r) {
-      if (r == null) {
-        return context.newResult();
-      }
-      Result<Record> res = context.newResult(r.fields());
-      res.add(r);
-      return res;
-    }
-
-    private Result<? extends Record> createResult(List<? extends Record> r) {
-      if (r.parallelStream().anyMatch(Objects::isNull)) {
-        throw new IllegalArgumentException("Record in provided list was null. No records "
-            + "should be null in a list of returns.");
-      }
-      if (r.size() == 0) {
-        return context.newResult();
-      }
-      Result<Record> res = context.newResult(r.get(0).fields());
-      res.addAll(r);
-      return res;
     }
 
     /**
@@ -242,6 +211,39 @@ public class JooqMock implements MockDataProvider {
       classMap.put(table.getName(), table);
     }
   }
+
+  /**
+   * Creates a result from a given record.
+   * @param r the Record to create a result for.
+   * @return the result for the given Record.
+   */
+  private Result<? extends Record> createResult(Record r) {
+    if (r == null) {
+      return context.newResult();
+    }
+    Result<Record> res = context.newResult(r.fields());
+    res.add(r);
+    return res;
+  }
+
+  /**
+   * Creates a result from a given record.
+   * @param r the List of Records to create a result for.
+   * @return the result for the given Records.
+   */
+  private Result<? extends Record> createResult(List<? extends Record> r) {
+    if (r.parallelStream().anyMatch(Objects::isNull)) {
+      throw new IllegalArgumentException("Record in provided list was null. No records "
+          + "should be null in a list of returns.");
+    }
+    if (r.size() == 0) {
+      return context.newResult();
+    }
+    Result<Record> res = context.newResult(r.get(0).fields());
+    res.addAll(r);
+    return res;
+  }
+
 
   /**
    * Add record to return during a call of execute. Will return this record after

--- a/service/src/test/java/com.codeforcommunity/JooqMock.java
+++ b/service/src/test/java/com.codeforcommunity/JooqMock.java
@@ -2,6 +2,8 @@ package com.codeforcommunity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Objects;
 import org.jooq.Table;
 import java.sql.SQLException;
 import java.util.List;
@@ -11,7 +13,6 @@ import org.jooq.Result;
 import org.jooq.SQLDialect;
 import org.jooq.generated.DefaultSchema;
 import org.jooq.impl.DSL;
-import org.jooq.impl.UpdatableRecordImpl;
 import org.jooq.tools.jdbc.*;
 import java.lang.String;
 import java.util.Map;
@@ -34,14 +35,14 @@ public class JooqMock implements MockDataProvider {
    */
   class Operations {
     // List of Supplier functions to call in order, acts as a queue for record Supplier functions
-    private List<Supplier<List<UpdatableRecordImpl>>> recordReturns;
+    private List<Supplier<Result<? extends Record>>> recordReturns;
     // Current location in the recordReturns list
     private int location = 0;
     // Count of times this operation has been called
     private int callCount = 0;
-    // SQL used for each call linked to each UpdatableRecordImpl returned (by position in list)
+    // SQL used for each call linked to each Record returned (by position in list)
     private List<List<String>> handlerSqlCalls;
-    // Bindings used for each call linked to each UpdatableRecordImpl returned
+    // Bindings used for each call linked to each Record returned
     private List<List<Object[]>> handlerSqlBindings;
 
     /**
@@ -60,9 +61,9 @@ public class JooqMock implements MockDataProvider {
      *
      * @param record The record to be returned during the first call of this operation.
      */
-    Operations(UpdatableRecordImpl record) {
+    Operations(Record record) {
       recordReturns = new ArrayList<>();
-      recordReturns.add(() -> Arrays.asList(record));
+      recordReturns.add(() -> createResult(record));
       handlerSqlCalls = new ArrayList<>();
       handlerSqlBindings = new ArrayList<>();
     }
@@ -73,9 +74,9 @@ public class JooqMock implements MockDataProvider {
      *
      * @param records The record to be returned during the first call of this operation.
      */
-    Operations(List<UpdatableRecordImpl> records) {
+    Operations(List<? extends Record> records) {
       recordReturns = new ArrayList<>();
-      recordReturns.add(() -> records);
+      recordReturns.add(() -> createResult(records));
       handlerSqlCalls = new ArrayList<>();
       handlerSqlBindings = new ArrayList<>();
     }
@@ -86,11 +87,33 @@ public class JooqMock implements MockDataProvider {
      *
      * @param recordFunction The first record Supplier to be called for this operation.
      */
-    Operations(Supplier<List<UpdatableRecordImpl>> recordFunction) {
+    Operations(Supplier<Result<? extends Record>> recordFunction) {
       recordReturns = new ArrayList<>();
       recordReturns.add(recordFunction);
       handlerSqlCalls = new ArrayList<>();
       handlerSqlBindings = new ArrayList<>();
+    }
+
+    private Result<? extends Record> createResult(Record r) {
+      if (r == null) {
+        return context.newResult();
+      }
+      Result<Record> res = context.newResult(r.fields());
+      res.add(r);
+      return res;
+    }
+
+    private Result<? extends Record> createResult(List<? extends Record> r) {
+      if (r.parallelStream().anyMatch(Objects::isNull)) {
+        throw new IllegalArgumentException("Record in provided list was null. No records "
+            + "should be null in a list of returns.");
+      }
+      if (r.size() == 0) {
+        return context.newResult();
+      }
+      Result<Record> res = context.newResult(r.get(0).fields());
+      res.addAll(r);
+      return res;
     }
 
     /**
@@ -98,16 +121,17 @@ public class JooqMock implements MockDataProvider {
      *
      * @param record Record to be returned at the end of the queue.
      */
-    private void addRecord(UpdatableRecordImpl record) {
-      recordReturns.add(() -> Arrays.asList(record));
+    private void addRecord(Record record) {
+      recordReturns.add(() -> createResult(record));
     }
 
     /**
      * Add a record to the end of the record Supplier queue by creating a Supplier for the given record.
-     * @param records
+     *
+     * @param records list of Record to be returned at the end of the queue.
      */
-    private void addRecord(List<UpdatableRecordImpl> records) {
-      recordReturns.add(() -> records);
+    private void addRecord(List<? extends Record> records) {
+      recordReturns.add(() -> createResult(records));
     }
 
     /**
@@ -115,8 +139,15 @@ public class JooqMock implements MockDataProvider {
      *
      * @param recordFunction Record supplier to be called at the end of the queue.
      */
-    private void addRecord(Supplier<List<UpdatableRecordImpl>> recordFunction) {
+    private void addRecord(Supplier<Result<? extends Record>> recordFunction) {
       recordReturns.add(recordFunction);
+    }
+
+    /**
+     * Adds an empty return to the end of the Supplier queue.
+     */
+    private void addEmptyReturn() {
+      recordReturns.add(() -> context.newResult());
     }
 
     /**
@@ -126,7 +157,7 @@ public class JooqMock implements MockDataProvider {
      * @param ctx The context supplied to execute.
      * @return TableRecord to be returned.
      */
-    List<UpdatableRecordImpl> call(MockExecuteContext ctx) {
+    Result<? extends Record> call(MockExecuteContext ctx) {
       callCount++;
 
       // handle creating new arrays and adding sql/bindings if first call at location in list
@@ -147,7 +178,7 @@ public class JooqMock implements MockDataProvider {
         return recordReturns.get(location).get();
       }
 
-      List<UpdatableRecordImpl> record = recordReturns.get(location).get();
+      Result<? extends Record> record = recordReturns.get(location).get();
       location++;
       return record;
     }
@@ -171,7 +202,7 @@ public class JooqMock implements MockDataProvider {
     }
 
     /**
-     * Return the SQL strings used with each call linked to each UpdatableRecordImpl
+     * Return the SQL strings used with each call linked to each Record
      *  returned by position in the list.
      * @return List<List<String>> of every SQL string used.
      */
@@ -180,7 +211,7 @@ public class JooqMock implements MockDataProvider {
     }
 
     /**
-     * Return the SQL bindings used with each call linked to each UpdatableRecordImpl.
+     * Return the SQL bindings used with each call linked to each Record.
      *
      * @return List<List<Object[]>> of all SQL bindings used.
      */
@@ -223,7 +254,10 @@ public class JooqMock implements MockDataProvider {
    * @param operation The operation to return this for (e.g. 'SELECT', 'INSERT', ...).
    * @param record The record to return
    */
-  public void addReturn(String operation, UpdatableRecordImpl record) {
+  public void addReturn(String operation, Record record) {
+    if (record == null && !recordReturns.containsKey(operation)) {
+      recordReturns.put(operation, new Operations(() -> context.newResult()));
+    }
     if (!recordReturns.containsKey(operation)) {
       recordReturns.put(operation, new Operations(record));
       return;
@@ -242,7 +276,7 @@ public class JooqMock implements MockDataProvider {
  * @param operation The operation to return this for (e.g. 'SELECT', 'INSERT', ...).
  * @param records The List of records to return
  */
-  public void addReturn(String operation, List<UpdatableRecordImpl> records) {
+  public void addReturn(String operation, List<? extends Record> records) {
     if (!recordReturns.containsKey(operation)) {
       recordReturns.put(operation, new Operations(records));
       return;
@@ -261,7 +295,7 @@ public class JooqMock implements MockDataProvider {
    * @param operation THe operation to run this for (e.g. 'SELECT', 'INSERT'...).
    * @param recordFunction The function to run when execute is called.
    */
-  public void addReturn(String operation, Supplier<List<UpdatableRecordImpl>> recordFunction) {
+  public void addReturn(String operation, Supplier<Result<? extends Record>> recordFunction) {
     if (!recordReturns.containsKey(operation)) {
       recordReturns.put(operation, new Operations(recordFunction));
       return;
@@ -279,12 +313,21 @@ public class JooqMock implements MockDataProvider {
    *
    * @param records A map of operations to records to be returned.
    */
-  public void addReturn(Map<String, List<UpdatableRecordImpl>> records) {
+  public void addReturn(Map<String, List<? extends Record>> records) {
     records.forEach((k, v) -> {
-      for (UpdatableRecordImpl record : v) {
+      for (Record record : v) {
         addReturn(k, record);
       }
     });
+  }
+
+  /**
+   * Adds an empty return to the last position for the current value.
+   *
+   * @param operation the operation to add the empty return to.
+   */
+  public void addEmptyReturn(String operation) {
+    addReturn(operation, Collections.emptyList());
   }
 
   /**
@@ -395,15 +438,15 @@ public class JooqMock implements MockDataProvider {
       return new MockResult(result.size(), result);
     }
 
-    Result<Record> result = context.newResult(classMap.get(table).fields());
+    Result<? extends Record> result;
     // catch and rethrow exception if return not primed
     try {
-      result.addAll(recordReturns.get(operation).call(ctx));
+      result = recordReturns.get(operation).call(ctx);
     }
     catch (NullPointerException e) {
-      throw new IllegalStateException("You probably forgot to prime your "
-          + "JooqMock by calling addReturn (with one of SELECT/INSERT/UPDATE/DELETE as "
-          + "your operation.");
+      System.out.println("WARNING: JooqMock could not find a primed result for the given operation,"
+          + "so an empty result is being returned. Provided SQL string was '" + ctx.sql() + "'");
+      result = context.newResult();
     }
     return new MockResult(result.size(), result);
   }


### PR DESCRIPTION
JooqMock can now:
- be more flexible with input types (you can now pass anything that implements/extends `Record` in, so no more dealing with weird `UpdatableRecordImpl` things)
- add ez empty return (you can now call `returnEmptyResult(<SQL operation>)` instead of having to instantiate an empty list, but that still works too :)
- allow non-generated jooq types to be returned (since you can pass in any `Record` types, you can also now pass in things like `Record3<String, Integer, Whatever>`, so subsets of an object's fields are now usable)
- stop requiring every expected call to be prepared (now if you make a query (like `SELECT`) without priming the db mock, it won't throw an error, but instead return an empty result while printing a warning and the SQL query that was called)