### PR TITLE
Integrate the S3Requester abstraction from the backend-scaffold

### DIFF
--- a/common/src/main/java/com/codeforcommunity/propertiesLoader/PropertiesLoader.java
+++ b/common/src/main/java/com/codeforcommunity/propertiesLoader/PropertiesLoader.java
@@ -49,11 +49,19 @@ public class PropertiesLoader {
     return getProperties("jwt.properties");
   }
 
+  public static Properties getStripeProperties() {
+    return getProperties("stripe.properties");
+  }
+
+  public static Properties getFrontendProperties() {
+    return getProperties("frontend.properties");
+  }
+
   public static Properties getSlackProperties() {
     return getProperties("slack.properties");
   }
 
   public static Properties getAwsProperties() {
-    return getProperties("properties/aws.properties");
+    return getProperties("aws.properties");
   }
 }

--- a/common/src/main/java/com/codeforcommunity/propertiesLoader/PropertiesLoader.java
+++ b/common/src/main/java/com/codeforcommunity/propertiesLoader/PropertiesLoader.java
@@ -1,48 +1,56 @@
 package com.codeforcommunity.propertiesLoader;
 
+import com.codeforcommunity.logger.SLogger;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 import java.util.Properties;
 
 public class PropertiesLoader {
+  private static final String basePath = "properties/";
 
   private static Properties getProperties(String file) {
+    String path = basePath + file;
 
-    try (InputStream input = PropertiesLoader.class.getClassLoader().getResourceAsStream(file)) {
+    try (InputStream input = PropertiesLoader.class.getClassLoader().getResourceAsStream(path)) {
       Properties prop = new Properties();
       prop.load(input);
       return prop;
-    } catch (IOException ex) {
-      throw new IllegalArgumentException("Cannot find file: " + file, ex);
+    } catch (IOException | NullPointerException e) {
+      String errorMsg = String.format("Failed to load file: `%s`", path);
+      SLogger.logApplicationError(e);
+      throw new IllegalArgumentException(errorMsg, e);
+    }
+  }
+
+  public static String loadProperty(Properties propFile, String propertyName) {
+    Optional<String> maybeProperty = Optional.ofNullable(propFile.getProperty(propertyName));
+    if (maybeProperty.isPresent()) {
+      return maybeProperty.get();
+    } else {
+      throw new IllegalArgumentException(
+          String.format("No property found `%s` in property file", propertyName));
     }
   }
 
   public static Properties getEmailerProperties() {
-    return getProperties("properties/emailer.properties");
+    return getProperties("emailer.properties");
   }
 
   public static Properties getDbProperties() {
-    return getProperties("properties/db.properties");
+    return getProperties("db.properties");
   }
 
   public static Properties getExpirationProperties() {
-    return getProperties("properties/expiration.properties");
+    return getProperties("expiration.properties");
   }
 
   public static Properties getJwtProperties() {
-    return getProperties("properties/jwt.properties");
-  }
-
-  public static Properties getStripeProperties() {
-    return getProperties("properties/stripe.properties");
-  }
-
-  public static Properties getFrontendProperties() {
-    return getProperties("properties/frontend.properties");
+    return getProperties("jwt.properties");
   }
 
   public static Properties getSlackProperties() {
-    return getProperties("properties/slack.properties");
+    return getProperties("slack.properties");
   }
 
   public static Properties getAwsProperties() {

--- a/service/src/test/java/com/codeforcommunity/processor/EventsProcessorImplTest.java
+++ b/service/src/test/java/com/codeforcommunity/processor/EventsProcessorImplTest.java
@@ -58,6 +58,13 @@ public class EventsProcessorImplTest {
   // 04/17/2020 @ 5:06am (UTC)
   private final int END_TIMESTAMP_TEST = 1587100000;
 
+  // sample public bucket URL to be used in tests
+  private final String BUCKET_PUBLIC_URL = "https://test-bucket.s3.us-east-2.amazonaws.com";
+  // sample public bucket name to be used in tests
+  private final String BUCKET_PUBLIC_NAME = "test-bucket";
+  // sample directory name to be used in tests
+  private final String DIR_NAME = "test-dir";
+
   @BeforeEach
   private void setup() {
     this.myJooqMock = new JooqMock();
@@ -72,6 +79,9 @@ public class EventsProcessorImplTest {
 
     when(mockS3Client.putObject(any(PutObjectRequest.class))).thenReturn(mockPutObjectResult);
     when(mockExterns.getS3Client()).thenReturn(mockS3Client);
+    when(mockExterns.getBucketPublic()).thenReturn(BUCKET_PUBLIC_NAME);
+    when(mockExterns.getBucketPublicUrl()).thenReturn(BUCKET_PUBLIC_URL);
+    when(mockExterns.getDirPublic()).thenReturn(DIR_NAME);
 
     S3Requester.setExterns(mockExterns);
   }
@@ -135,9 +145,7 @@ public class EventsProcessorImplTest {
     assertEquals(res.getId(), 0);
     assertEquals(res.getTitle(), "sample");
     assertEquals(res.getCapacity(), 5);
-    assertEquals(
-        res.getThumbnail(),
-        "https://lucys-love-bus.s3.us-east-2.amazonaws.com/events/sample_thumbnail.gif");
+    assertEquals(res.getThumbnail(), BUCKET_PUBLIC_URL + "/" + DIR_NAME + "/sample_thumbnail.gif");
     assertEquals(res.getDetails().getDescription(), myEventDetails.getDescription());
     assertEquals(res.getDetails().getLocation(), myEventDetails.getLocation());
     assertEquals(res.getDetails().getEnd(), myEventDetails.getEnd());


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/677600458/pulses/785276664)

What benefit does this bring to the end user? Or, what benefit does this bring to developers 
working in the codebase?

This is one step in the process of allowing a user to edit images in an event. It gets rid of the hardcoded variables in the S3Requester file and moves them into separate property files.

## This PR

I copied over the code in S3Requester.java and PropertiesLoader.java files. I also removed the AWS properties fields from S3Requester class and added them to the Externs inner class. There was a failing test creating an event that I fixed by removing the s3Client field from S3Requester and using the Externs s3Client instead. I also changed a test in EventsProcessorImplTest which depended on a hardcoded S3 bucket URL to rely on a dummy value created during test setup.

## Screenshots

None

## Verification Steps

I ran the test suite (by deleting the target folders in api, src, common, etc. and then running mvn clean install).