### PR TITLE
Change Event Confirmation Email

### DIFF
--- a/service/src/main/java/com/codeforcommunity/requester/Emailer.java
+++ b/service/src/main/java/com/codeforcommunity/requester/Emailer.java
@@ -155,7 +155,7 @@ public class Emailer {
       String eventName,
       String eventDate,
       String eventTime) {
-    String filePath = "/emails/PfRequestApproved.html";
+    String filePath = "/emails/RegistrationConfirmation.html";
     String subjectLine = String.format("You're Registered for %s!", eventName);
 
     Map<String, String> templateValues = new HashMap<>();


### PR DESCRIPTION
## Why

The Event Confirmation Email does not point to the right file.

## This PR

Uses the right template 

## Screenshots

Local email verification

![Screen Shot 2020-12-08 at 3 30 42 PM](https://user-images.githubusercontent.com/15748593/101553855-7ddbfc00-3983-11eb-91b0-4d5f06e55cd8.png)
