### PR TITLE
Added referrer to new user request + database contact

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/auth/NewUserRequest.java
+++ b/api/src/main/java/com/codeforcommunity/dto/auth/NewUserRequest.java
@@ -14,6 +14,7 @@ public class NewUserRequest extends ApiDto {
   private AddressData location;
   private String phoneNumber;
   private String allergies;
+  private String referrer;
 
   public NewUserRequest(
       String email,
@@ -22,7 +23,8 @@ public class NewUserRequest extends ApiDto {
       String lastName,
       AddressData location,
       String phoneNumber,
-      String allergies) {
+      String allergies,
+      String referrer) {
     this.email = email;
     this.password = password;
     this.firstName = firstName;
@@ -30,6 +32,7 @@ public class NewUserRequest extends ApiDto {
     this.location = location;
     this.phoneNumber = phoneNumber;
     this.allergies = allergies;
+    this.referrer = referrer;
   }
 
   private NewUserRequest() {}
@@ -182,5 +185,23 @@ public class NewUserRequest extends ApiDto {
    */
   public void setAllergies(String allergies) {
     this.allergies = allergies;
+  }
+
+  /**
+   * Retrieves the referrer field.
+   *
+   * @return the String referrer field.
+   */
+  public String getReferrer() {
+    return this.referrer;
+  }
+
+  /**
+   * Sets this NewUserRequest's referrer field to the provided referrer.
+   *
+   * @param referrer the value to set this referrer field to.
+   */
+  public void setReferrer(String referrer) {
+    this.referrer = referrer;
   }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/protected_user/components/Contact.java
+++ b/api/src/main/java/com/codeforcommunity/dto/protected_user/components/Contact.java
@@ -26,6 +26,7 @@ public class Contact extends ApiDto {
   private String notes;
   private String pronouns;
   private Boolean shouldSendEmails;
+  private String referrer;
 
   /** Creates a contact with no information (all fields null). */
   public Contact() {}
@@ -58,7 +59,8 @@ public class Contact extends ApiDto {
       String medication,
       String notes,
       String pronouns,
-      Boolean shouldSendEmails) {
+      Boolean shouldSendEmails,
+      String referrer) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
@@ -71,6 +73,7 @@ public class Contact extends ApiDto {
     this.notes = notes;
     this.pronouns = pronouns;
     this.shouldSendEmails = shouldSendEmails;
+    this.referrer = referrer;
   }
 
   /**
@@ -313,5 +316,23 @@ public class Contact extends ApiDto {
    */
   public void setShouldSendEmails(Boolean shouldSendEmails) {
     this.shouldSendEmails = shouldSendEmails;
+  }
+
+  /**
+   * Returns this Contact's referrer.
+   *
+   * @return this Contact's referrer.
+   */
+  public String getReferrer() {
+    return this.referrer;
+  }
+
+  /**
+   * Sets this Contact's referrer to the given one.
+   *
+   * @param referrer the new referrer.
+   */
+  public void setReferrer(String referrer) {
+    this.referrer = referrer;
   }
 }

--- a/persist/src/main/resources/db/migration/V11__UpdateContact.sql
+++ b/persist/src/main/resources/db/migration/V11__UpdateContact.sql
@@ -1,0 +1,1 @@
+ALTER TABLE contacts ADD COLUMN referrer TEXT DEFAULT null;

--- a/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
+++ b/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
@@ -135,6 +135,7 @@ public class AuthDatabaseOperations {
     mainContact.setLastName(request.getLastName());
     mainContact.setPhoneNumber(request.getPhoneNumber());
     mainContact.setAllergies(request.getAllergies());
+    mainContact.setReferrer(request.getReferrer());
     mainContact.store();
 
     String verificationToken = createSecretKey(newUser.getId(), VerificationKeyType.VERIFY_EMAIL);

--- a/service/src/test/java/com/codeforcommunity/dataaccess/AuthDatabaseOperationsTest.java
+++ b/service/src/test/java/com/codeforcommunity/dataaccess/AuthDatabaseOperationsTest.java
@@ -123,7 +123,8 @@ public class AuthDatabaseOperationsTest {
     myJooqMock.addReturn("SELECT", myUser);
 
     NewUserRequest req =
-        new NewUserRequest(myEmail, "letmeout", "Brandon", "Liang", null, null, null);
+        new NewUserRequest(
+            myEmail, "letmeout", "Brandon", "Liang", null, null, null, "Brandon's referrer");
 
     try {
       myAuthDatabaseOperations.createNewUser(req);
@@ -146,6 +147,7 @@ public class AuthDatabaseOperationsTest {
     AddressData sampleLocation = new AddressData("420 Hemenway Street", "Boston", "MA", "02115");
     String samplePN = "200-233-4334";
     String sampleAllergies = "Eggs/Fish";
+    String sampleReferrer = "Conner's referrer";
 
     NewUserRequest req =
         new NewUserRequest(
@@ -155,7 +157,8 @@ public class AuthDatabaseOperationsTest {
             sampleLN,
             sampleLocation,
             samplePN,
-            sampleAllergies);
+            sampleAllergies,
+            sampleReferrer);
 
     myJooqMock.addEmptyReturn("SELECT");
     myJooqMock.addEmptyReturn("UPDATE");

--- a/service/src/test/java/com/codeforcommunity/processor/AuthProcessorImplTest.java
+++ b/service/src/test/java/com/codeforcommunity/processor/AuthProcessorImplTest.java
@@ -85,7 +85,8 @@ public class AuthProcessorImplTest {
             "Liang",
             new AddressData("West 5th Street", "New York", "NY", "10002"),
             "555-555-5555",
-            "Peanuts");
+            "Peanuts",
+            "Brandon's referrer");
 
     SessionResponse res = myAuthProcessorImpl.signUp(req);
 

--- a/service/src/test/java/com/codeforcommunity/processor/ProtectedUserProcessorImplTest.java
+++ b/service/src/test/java/com/codeforcommunity/processor/ProtectedUserProcessorImplTest.java
@@ -48,7 +48,8 @@ public class ProtectedUserProcessorImplTest {
           "claritin",
           "none",
           "he/him/his",
-          true);
+          true,
+          "Brandon's referrer");
 
   private final Contact CONTACT_EXAMPLE_2 =
       new Contact(
@@ -64,7 +65,8 @@ public class ProtectedUserProcessorImplTest {
           null,
           "helped me a lot with writing these tests :)",
           "he/him/his",
-          false);
+          false,
+          "Conner's referrer");
 
   private final Contact CONTACT_EXAMPLE_3 =
       new Contact(
@@ -79,7 +81,8 @@ public class ProtectedUserProcessorImplTest {
           null,
           "analytical engine",
           "she/her/hers",
-          false);
+          false,
+          "Ada's referrer");
 
   private final Child CHILD_EXAMPLE_1 =
       new Child(


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/677600458/pulses/836864835)

Now users will be able to specify a referring organization when registering themselves on LLB. This could help us see and LLB see how people are finding out about LLB.

## This PR

- To make this happen, I add to add a `String referrer` field to the NewUser DTO, which in turn made me add the field to the Contact POJO.
- I added a migration file to properly reflect the change in the database.
- I also adjusted the tests to have a referrer field.

## Screenshots

Making a POST request with the referrer field:
![image](https://user-images.githubusercontent.com/46979800/101695597-d7573000-3a42-11eb-9524-d62571cee200.png)

The successful response:
![image](https://user-images.githubusercontent.com/46979800/101695626-e50cb580-3a42-11eb-82a7-e8c24a1d354f.png)

Regression test: Making a POST request **without** the referrer field to make sure nothing broke:
![image](https://user-images.githubusercontent.com/46979800/101695711-ff469380-3a42-11eb-9163-0c572c58a1df.png)

The successful response:
![image](https://user-images.githubusercontent.com/46979800/101695731-07063800-3a43-11eb-87a7-c8760c030994.png)

Screenshot to show that the backend was actually modified (can't see the whole row in one image so I uploaded two screenshots):
![image](https://user-images.githubusercontent.com/46979800/101695916-4b91d380-3a43-11eb-9fc8-3246edfa8f76.png)
![image](https://user-images.githubusercontent.com/46979800/101695960-5a788600-3a43-11eb-863c-8b42115d4d88.png)

As you can see above, the referrer is `null` for the user who did not specify a referrer, and then it properly adds the referrer when it was specified.

## Verification Steps

To verify it worked, I made two POST requests, one with the referrer and one without. This shows that a referrer can now truly be included as part of a new user, but also that everything is working normally in the case that they don't (as it is an optional field during registration). 
Note: the frontend has not been adjusted to have a referrer field yet and I only tested via Postman, but I believe that in our React redesign we will have actually have the designated field for it. In the case that we want to add that field to our old Vue frontend, a separate ticket can be made for that. 