### PR TITLE
Update JSON response and setting profile picture for additional contacts and children

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/protected_user/components/Child.java
+++ b/api/src/main/java/com/codeforcommunity/dto/protected_user/components/Child.java
@@ -1,7 +1,6 @@
 package com.codeforcommunity.dto.protected_user.components;
 
 import com.codeforcommunity.dto.ApiDto;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +14,6 @@ public class Child extends ApiDto {
   private String firstName;
   private String lastName;
 
-  @JsonFormat(pattern = "yyyy-MM-dd")
   private Date dateOfBirth;
 
   private String pronouns;

--- a/api/src/main/java/com/codeforcommunity/dto/protected_user/components/Contact.java
+++ b/api/src/main/java/com/codeforcommunity/dto/protected_user/components/Contact.java
@@ -1,7 +1,6 @@
 package com.codeforcommunity.dto.protected_user.components;
 
 import com.codeforcommunity.dto.ApiDto;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,8 +13,6 @@ public class Contact extends ApiDto {
 
   private String firstName;
   private String lastName;
-
-  @JsonFormat(pattern = "yyyy-MM-dd")
   private Date dateOfBirth;
 
   private String email;

--- a/service/src/main/java/com/codeforcommunity/dataaccess/UserInformationDatabaseOperations.java
+++ b/service/src/main/java/com/codeforcommunity/dataaccess/UserInformationDatabaseOperations.java
@@ -57,11 +57,16 @@ public class UserInformationDatabaseOperations {
       throw new UserDoesNotExistException(userData.getUserId());
     }
 
-    String filename = "profile-" + UUID.randomUUID();
-    String publicImageUrl =
-        S3Requester.validateUploadImageToS3LucyEvents(filename, newContactData.getProfilePicture());
-
-    newContactData.setProfilePicture(publicImageUrl); // Actually setting Image URL
+    if (newContactData.getProfilePicture() == null
+        || newContactData.getProfilePicture().startsWith("http")) {
+      newContactData.setProfilePicture(newContactData.getProfilePicture());
+    } else {
+      String filename = "profile-" + UUID.randomUUID();
+      String publicImageUrl =
+          S3Requester.validateUploadImageToS3LucyEvents(
+              filename, newContactData.getProfilePicture());
+      newContactData.setProfilePicture(publicImageUrl); // Actually setting Image URL
+    }
 
     newContactData.setShouldSendEmails(true);
     updateStoreContactRecord(mainContact, newContactData);
@@ -81,11 +86,6 @@ public class UserInformationDatabaseOperations {
   public void addAdditionalContacts(List<Contact> additionalContacts, JWTData userData) {
     for (Contact contact : additionalContacts) {
       ContactsRecord contactsRecord = db.newRecord(CONTACTS);
-
-      String filename = "profile-" + UUID.randomUUID();
-      String publicImageUrl =
-          S3Requester.validateUploadImageToS3LucyEvents(filename, contact.getProfilePicture());
-      contact.setProfilePicture(publicImageUrl); // Actually setting Image URL
 
       contactsRecord.setUserId(userData.getUserId());
       updateStoreContactRecord(contactsRecord, contact);
@@ -122,6 +122,17 @@ public class UserInformationDatabaseOperations {
 
   /** Update and store a contact record to reflect a contact dto. */
   public void updateStoreContactRecord(ContactsRecord contactsRecord, Contact contactDto) {
+    if (contactDto.getProfilePicture() == null
+        || contactDto.getProfilePicture().startsWith("http")) {
+      contactsRecord.setProfilePicture(contactDto.getProfilePicture());
+    } else {
+      String filename = "profile-" + UUID.randomUUID();
+      String publicImageUrl =
+          S3Requester.validateUploadImageToS3LucyEvents(
+              filename, contactDto.getProfilePicture());
+      contactsRecord.setProfilePicture(publicImageUrl); // Actually setting Image URL
+    }
+
     contactsRecord.setFirstName(contactDto.getFirstName());
     contactsRecord.setLastName(contactDto.getLastName());
     contactsRecord.setDateOfBirth(contactDto.getDateOfBirth());
@@ -133,7 +144,6 @@ public class UserInformationDatabaseOperations {
     contactsRecord.setNotes(contactDto.getNotes());
     contactsRecord.setShouldSendEmails(contactDto.getShouldSendEmails());
     contactsRecord.setPhoneNumber(contactDto.getPhoneNumber());
-    contactsRecord.setProfilePicture(contactDto.getProfilePicture());
     contactsRecord.setReferrer(contactDto.getReferrer());
 
     contactsRecord.store();
@@ -141,6 +151,17 @@ public class UserInformationDatabaseOperations {
 
   /** Update and store a children record to reflect a child dto. */
   public void updateStoreChildRecord(ChildrenRecord childrenRecord, Child childDto) {
+    if (childDto.getProfilePicture() == null
+        || childDto.getProfilePicture().startsWith("http")) {
+      childrenRecord.setProfilePicture(childDto.getProfilePicture());
+    } else {
+      String filename = "profile-" + UUID.randomUUID();
+      String publicImageUrl =
+          S3Requester.validateUploadImageToS3LucyEvents(
+              filename, childDto.getProfilePicture());
+      childrenRecord.setProfilePicture(publicImageUrl); // Actually setting Image URL
+    }
+
     childrenRecord.setFirstName(childDto.getFirstName());
     childrenRecord.setLastName(childDto.getLastName());
     childrenRecord.setDateOfBirth(childDto.getDateOfBirth());
@@ -151,7 +172,6 @@ public class UserInformationDatabaseOperations {
     childrenRecord.setDiagnosis(childDto.getDiagnosis());
     childrenRecord.setMedications(childDto.getMedications());
     childrenRecord.setNotes(childDto.getNotes());
-    childrenRecord.setProfilePicture(childDto.getProfilePicture());
 
     childrenRecord.store();
   }


### PR DESCRIPTION
## Why

This PR is required for a frontend ticket so that updating profile information is idempotent and setting profile pictures works properly, in particular:
- Setting a profile picture with a URL or null value will not result in S3 processing
- Setting a profile picture for children and additional contacts works the same as  the main contact

Also, the JSON schema for the date of birth field was standardized to the integer format that we use in our other API endpoints.


