### PR TITLE
Event On Delete Cascade

### DIFF
--- a/service/src/main/java/com/codeforcommunity/processor/EventsProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/EventsProcessorImpl.java
@@ -1,11 +1,5 @@
 package com.codeforcommunity.processor;
 
-import static org.jooq.generated.Tables.CHILDREN;
-import static org.jooq.generated.Tables.CONTACTS;
-import static org.jooq.generated.Tables.EVENTS;
-import static org.jooq.generated.Tables.EVENT_REGISTRATIONS;
-import static org.jooq.generated.Tables.USERS;
-
 import com.codeforcommunity.api.IEventsProcessor;
 import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dataaccess.EventDatabaseOperations;
@@ -25,6 +19,13 @@ import com.codeforcommunity.exceptions.EventDoesNotExistException;
 import com.codeforcommunity.exceptions.InvalidEventCapacityException;
 import com.codeforcommunity.exceptions.S3FailedUploadException;
 import com.codeforcommunity.requester.S3Requester;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.SelectConditionStep;
+import org.jooq.SelectSeekStep1;
+import org.jooq.generated.tables.pojos.Events;
+import org.jooq.generated.tables.records.EventsRecord;
+
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -33,12 +34,13 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.jooq.DSLContext;
-import org.jooq.Record;
-import org.jooq.SelectConditionStep;
-import org.jooq.SelectSeekStep1;
-import org.jooq.generated.tables.pojos.Events;
-import org.jooq.generated.tables.records.EventsRecord;
+
+import static org.jooq.generated.Tables.ANNOUNCEMENTS;
+import static org.jooq.generated.Tables.CHILDREN;
+import static org.jooq.generated.Tables.CONTACTS;
+import static org.jooq.generated.Tables.EVENTS;
+import static org.jooq.generated.Tables.EVENT_REGISTRATIONS;
+import static org.jooq.generated.Tables.USERS;
 
 public class EventsProcessorImpl implements IEventsProcessor {
 
@@ -211,6 +213,9 @@ public class EventsProcessorImpl implements IEventsProcessor {
     if (userData.getPrivilegeLevel() != PrivilegeLevel.ADMIN) {
       throw new AdminOnlyRouteException();
     }
+
+    db.delete(ANNOUNCEMENTS).where(ANNOUNCEMENTS.EVENT_ID.eq((eventId))).execute();
+    db.delete(EVENT_REGISTRATIONS).where(EVENT_REGISTRATIONS.EVENT_ID.eq(eventId)).execute();
     db.delete(EVENTS).where(EVENTS.ID.eq(eventId)).execute();
   }
 

--- a/service/src/main/java/com/codeforcommunity/processor/EventsProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/EventsProcessorImpl.java
@@ -25,6 +25,7 @@ import org.jooq.SelectConditionStep;
 import org.jooq.SelectSeekStep1;
 import org.jooq.generated.tables.pojos.Events;
 import org.jooq.generated.tables.records.EventsRecord;
+import org.jooq.impl.DSL;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -214,9 +215,13 @@ public class EventsProcessorImpl implements IEventsProcessor {
       throw new AdminOnlyRouteException();
     }
 
-    db.delete(ANNOUNCEMENTS).where(ANNOUNCEMENTS.EVENT_ID.eq((eventId))).execute();
-    db.delete(EVENT_REGISTRATIONS).where(EVENT_REGISTRATIONS.EVENT_ID.eq(eventId)).execute();
-    db.delete(EVENTS).where(EVENTS.ID.eq(eventId)).execute();
+    db.transaction(
+        configuration -> {
+          DSLContext ctx = DSL.using(configuration);
+          ctx.delete(ANNOUNCEMENTS).where(ANNOUNCEMENTS.EVENT_ID.eq((eventId))).execute();
+          ctx.delete(EVENT_REGISTRATIONS).where(EVENT_REGISTRATIONS.EVENT_ID.eq(eventId)).execute();
+          ctx.delete(EVENTS).where(EVENTS.ID.eq(eventId)).execute();
+        });
   }
 
   @Override


### PR DESCRIPTION
## Why

Adds cascading delete when deleting events so announcements and registrations are deleted from the database when corresponding events are deleted.

## This PR

Adds two database operations in deleteEvent()

## Screenshots

N/A

## Verification Steps

1. Make a new event
2. Go to that event's page
3. Add an announcement
4. Go to PgAdmin and check that that there is a new event and a new announcement. The announcement's event_id should be same as the event's ID.
5. Delete the event
6. Verify that the event and the announcement are deleted